### PR TITLE
autoincrementing unique ids for the xmlsitemap table

### DIFF
--- a/includes/db.inc
+++ b/includes/db.inc
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Functionality that touches the database.
+ */
+
+/**
+ * Inserts a record into the autoincrementing ID table.
+ *
+ * @param string $value
+ *   The value to insert into the 'pid' column.
+ */
+function islandora_xmlsitemap_insert_increment_record($value) {
+  db_insert('islandora_xmlsitemap_entry_ids')
+    ->fields(array('pid' => $value))
+    ->execute();
+}
+
+/**
+ * Deletes a record from the autoincrementing ID table.
+ *
+ * @param string $value
+ *   The value to match in the 'pid' column for record deletion.
+ */
+function islandora_xmlsitemap_delete_increment_record($value) {
+  db_delete('islandora_xmlsitemap_entry_ids')
+    ->condition('pid', $value)
+    ->execute();
+}
+
+/**
+ * Gets an incremented ID from the autoincrementing table.
+ *
+ * Does so by entering a row, querying for that record, and then immediately
+ * deleting that row.
+ *
+ * @param string $value
+ *   A unique value to use in the 'pid' column to ensure a unique incremented
+ *   ID.
+ *
+ * @return int
+ *   A unique, incremented ID from the table.
+ */
+function islandora_xmlsitemap_get_incremented_id($value) {
+  islandora_xmlsitemap_insert_increment_record($value);
+  $id = db_select('islandora_xmlsitemap_entry_ids', 'x')
+    ->fields('x', array('id'))
+    ->condition('pid', $value)
+    ->execute()
+    ->fetchField();
+  islandora_xmlsitemap_delete_increment_record($value);
+  return $id;
+}

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -30,25 +30,19 @@ function islandora_xmlsitemap_delete_increment_record($value) {
 }
 
 /**
- * Gets an incremented ID from the autoincrementing table.
- *
- * Does so by entering a row, querying for that record, and then immediately
- * deleting that row.
+ * Gets a record from the autoincrementing ID table.
  *
  * @param string $value
- *   A unique value to use in the 'pid' column to ensure a unique incremented
- *   ID.
+ *   The record to get an autoincrementing ID for.
  *
  * @return int
- *   A unique, incremented ID from the table.
+ *   The ID for that record.
  */
-function islandora_xmlsitemap_get_incremented_id($value) {
-  islandora_xmlsitemap_insert_increment_record($value);
+function islandora_xmlsitemap_get_id_for_record($value) {
   $id = db_select('islandora_xmlsitemap_entry_ids', 'x')
     ->fields('x', array('id'))
     ->condition('pid', $value)
     ->execute()
     ->fetchField();
-  islandora_xmlsitemap_delete_increment_record($value);
   return $id;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -67,7 +67,13 @@ function islandora_xmlsitemap_add_or_update_link($pid, &$sandbox = NULL) {
   $link += (array) islandora_xmlsitemap_get_current($pid);
   if (!isset($link['id'])) {
     module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
-    $link['id'] = islandora_xmlsitemap_get_incremented_id($pid);
+    try {
+      islandora_xmlsitemap_insert_increment_record($pid);
+    }
+    catch (PDOException $e) {
+      // Don't do anything in this case; we already have an ID.
+    }
+    $link['id'] = islandora_xmlsitemap_get_id_for_record($pid);
   }
 
   return xmlsitemap_link_save($link);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -94,15 +94,3 @@ EOQ;
     ':loc' => islandora_xmlsitemap_get_link_url($pid),
   ))->fetch(PDO::FETCH_ASSOC);
 }
-
-/**
- * Gets the next link ID from this module's custom table.
- *
- * @param string $pid
- *   The PID to insert into the table for this link ID.
- *
- * @return int
- *   The next ID.
- */
-function islandora_xmlsitemap_get_next_link_id($pid) {
-}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -66,10 +66,8 @@ function islandora_xmlsitemap_add_or_update_link($pid, &$sandbox = NULL) {
   }
   $link += (array) islandora_xmlsitemap_get_current($pid);
   if (!isset($link['id'])) {
-    // An 'id' value would have been obtained by adding in the current link
-    // structure... Apparently, we're adding a new link, so let's grab the next
-    // 'custom' ID.
-    $link['id'] = db_query("SELECT MAX(id) FROM {xmlsitemap} WHERE type = 'custom'")->fetchField() + 1;
+    module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
+    $link['id'] = islandora_xmlsitemap_get_incremented_id($pid);
   }
 
   return xmlsitemap_link_save($link);
@@ -95,4 +93,16 @@ EOQ;
     ':sub_id' => islandora_xmlsitemap_get_subtype_id($pid),
     ':loc' => islandora_xmlsitemap_get_link_url($pid),
   ))->fetch(PDO::FETCH_ASSOC);
+}
+
+/**
+ * Gets the next link ID from this module's custom table.
+ *
+ * @param string $pid
+ *   The PID to insert into the table for this link ID.
+ *
+ * @return int
+ *   The next ID.
+ */
+function islandora_xmlsitemap_get_next_link_id($pid) {
 }

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -21,6 +21,8 @@ function islandora_xmlsitemap_uninstall() {
  * Implements hook_install().
  */
 function islandora_xmlsitemap_install() {
+  // XXX: Taking advantage of the update hook's batch functionality to run the
+  // same batch on install as one would have to in the update hook.
   islandora_xmlsitemap_update_7000();
 }
 

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -51,6 +51,7 @@ function islandora_xmlsitemap_schema() {
       ),
       'primary key' => array('id'),
       'unique keys' => array('pid' => array('pid')),
+      'indexes' => array('pid_index' => array('pid')),
     ),
   );
 }
@@ -60,36 +61,41 @@ function islandora_xmlsitemap_schema() {
  */
 function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
   module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
-  if (!isset($sandbox['target'])) {
+  if (empty($sandbox)) {
     // Create our table, if it doesn't exist.
     if (!db_table_exists('islandora_xmlsitemap_entry_ids')) {
       $schema = islandora_xmlsitemap_schema();
       db_create_table('islandora_xmlsitemap_entry_ids', $schema['islandora_xmlsitemap_entry_ids']);
     }
-    // Set an initial value.
-    islandora_xmlsitemap_insert_increment_record(NULL);
-    // And immediately give it the boot.
-    islandora_xmlsitemap_delete_increment_record(NULL);
-    // Get the current max.
-    $q = db_select('xmlsitemap', 'x');
-    $q->addExpression('MAX(id)');
-    $q->condition('type', 'custom', '=');
-    $current_id = $q->execute()->fetchField();
-    $sandbox['target'] = $current_id !== FALSE ? $current_id : 1;
+    // Get the total of 'custom' records.
+    $sandbox['total'] = db_select('xmlsitemap', 'x')
+      ->condition('type', 'custom', '=')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
     $sandbox['current'] = 0;
   }
 
-  // XXX: there are a few conditions where the ID for this table can't simply
-  // start at 1, so we iterate the auto-incrementing ID field in batch to the
-  // point where it's supposed to be. It's a little bit goofy to do it this way,
-  // but databases handle auto-increment fields differently, so the method to
-  // set it needs to be database-agnostic.
-  foreach (array_fill(0, min(1000, $sandbox['target'] - $sandbox['current']), NULL) as $increment) {
-    islandora_xmlsitemap_insert_increment_record($increment);
-    islandora_xmlsitemap_delete_increment_record($increment);
+  // Could be empty.
+  if ($sandbox['total'] == 0) {
+    $context['#finished'] = 1;
+    return;
+  }
+
+  // Insert any existing records, 1000 at a time.
+  $records = db_select('xmlsitemap', 'x')
+    ->fields('x', array('id', 'subtype'))
+    ->condition('type', 'custom', '=')
+    ->orderBy('id', 'ASC')
+    ->range(0, 1000)
+    ->execute()
+    ->fetchAllAssoc('id');
+  foreach ($records as $record) {
+    $pid = str_replace('info:fedora/', '', $record->subtype);
+    islandora_xmlsitemap_insert_increment_record($pid);
     $sandbox['current']++;
   }
 
   // Are we done?
-  $context['#finished'] = $sandbox['current'] / $sandbox['target'];
+  $context['#finished'] = $sandbox['current'] / $sandbox['total'];
 }

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -51,7 +51,6 @@ function islandora_xmlsitemap_schema() {
       ),
       'primary key' => array('id'),
       'unique keys' => array('pid' => array('pid')),
-      'indexes' => array('pid_index' => array('pid')),
     ),
   );
 }

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -31,6 +31,10 @@ function islandora_xmlsitemap_install() {
  */
 function islandora_xmlsitemap_schema() {
   return array(
+    // This table satisfies a race condition where we cannot guarantee unique
+    // IDs in the xmlsitemap table when ingesting concurrently, so we generate
+    // them here instead. See https://jira.duraspace.org/browse/ISLANDORA-1784
+    // for more details.
     'islandora_xmlsitemap_entry_ids' => array(
       'description' => 'Autoincrementing table to store IDs we can use for xmlsitemap table entries.',
       'fields' => array(
@@ -42,26 +46,17 @@ function islandora_xmlsitemap_schema() {
         'pid' => array(
           'description' => 'The PID relating to this ID.',
           'type' => 'varchar',
-          'length' => 255,
+          'length' => 64,
         ),
       ),
       'primary key' => array('id'),
+      'unique keys' => array('pid' => array('pid')),
     ),
   );
 }
 
 /**
- * Add the ID table schema in.
- *
- * XXX: satisfies a race condition (details in the @see below); the best way to
- * satisfy this condition was using an auto-incrementing ID in a table, but if
- * islandora_xmlsitemap is already in use, the ID likely can't simply start at
- * 1. This function iterates the auto-incrementing ID field to the point where
- * it's supposed to be. It's a little bit goofy to do it this way, but it
- * ensures that the method we're using to set the initial ID is database-
- * agnostic.
- *
- * @see https://jira.duraspace.org/browse/ISLANDORA-1784
+ * Add the ID table schema in, and set the initial ID.
  */
 function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
   module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
@@ -81,12 +76,17 @@ function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
     $q->condition('type', 'custom', '=');
     $current_id = $q->execute()->fetchField();
     $sandbox['target'] = $current_id !== FALSE ? $current_id : 1;
-    $sandbox['current'] = 1;
+    $sandbox['current'] = 0;
   }
 
-  // Start filling in records.
+  // XXX: there are a few conditions where the ID for this table can't simply
+  // start at 1, so we iterate the auto-incrementing ID field in batch to the
+  // point where it's supposed to be. It's a little bit goofy to do it this way,
+  // but databases handle auto-increment fields differently, so the method to
+  // set it needs to be database-agnostic.
   foreach (array_fill(0, min(1000, $sandbox['target'] - $sandbox['current']), NULL) as $increment) {
-    islandora_xmlsitemap_get_incremented_id($increment);
+    islandora_xmlsitemap_insert_increment_record($increment);
+    islandora_xmlsitemap_delete_increment_record($increment);
     $sandbox['current']++;
   }
 

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -86,7 +86,7 @@ function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
     ->fields('x', array('id', 'subtype'))
     ->condition('type', 'custom', '=')
     ->orderBy('id', 'ASC')
-    ->range(0, 1000)
+    ->range($sandbox['current'], 1000)
     ->execute()
     ->fetchAllAssoc('id');
   foreach ($records as $record) {

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -13,7 +13,81 @@ function islandora_xmlsitemap_uninstall() {
     'islandora_xmlsitemap_number_of_pids_to_process',
     'islandora_xmlsitemap_last_modified_value',
     'islandora_xmlsitemap_last_modified_field',
-    'islandora_namespace_restriction_enforced',
   );
   array_walk($variables, 'variable_del');
+}
+
+/**
+ * Implements hook_install().
+ */
+function islandora_xmlsitemap_install() {
+  islandora_xmlsitemap_update_7000();
+}
+
+/**
+ * Implements hook_schema().
+ */
+function islandora_xmlsitemap_schema() {
+  return array(
+    'islandora_xmlsitemap_entry_ids' => array(
+      'description' => 'Autoincrementing table to store IDs we can use for xmlsitemap table entries.',
+      'fields' => array(
+        'id' => array(
+          'description' => 'Current ID number',
+          'type' => 'serial',
+          'not null' => TRUE,
+        ),
+        'pid' => array(
+          'description' => 'The PID relating to this ID.',
+          'type' => 'varchar',
+          'length' => 255,
+        ),
+      ),
+      'primary key' => array('id'),
+    ),
+  );
+}
+
+/**
+ * Add the ID table schema in.
+ *
+ * XXX: satisfies a race condition (details in the @see below); the best way to
+ * satisfy this condition was using an auto-incrementing ID in a table, but if
+ * islandora_xmlsitemap is already in use, the ID likely can't simply start at
+ * 1. This function iterates the auto-incrementing ID field to the point where
+ * it's supposed to be. It's a little bit goofy to do it this way, but it
+ * ensures that the method we're using to set the initial ID is database-
+ * agnostic.
+ *
+ * @see https://jira.duraspace.org/browse/ISLANDORA-1784
+ */
+function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
+  module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
+  if (!isset($sandbox['target'])) {
+    // Create our table, if it doesn't exist.
+    if (!db_table_exists('islandora_xmlsitemap_entry_ids')) {
+      $schema = islandora_xmlsitemap_schema();
+      db_create_table('islandora_xmlsitemap_entry_ids', $schema['islandora_xmlsitemap_entry_ids']);
+    }
+    // Set an initial value.
+    islandora_xmlsitemap_insert_increment_record(NULL);
+    // And immediately give it the boot.
+    islandora_xmlsitemap_delete_increment_record(NULL);
+    // Get the current max.
+    $q = db_select('xmlsitemap', 'x');
+    $q->addExpression('MAX(id)');
+    $q->condition('type', 'custom', '=');
+    $current_id = $q->execute()->fetchField();
+    $sandbox['target'] = $current_id !== FALSE ? $current_id : 1;
+    $sandbox['current'] = 1;
+  }
+
+  // Start filling in records.
+  foreach (array_fill(0, min(100, $sandbox['target'] - $sandbox['current']), NULL) as $increment) {
+    islandora_xmlsitemap_get_incremented_id($increment);
+    $sandbox['current']++;
+  }
+
+  // Are we done?
+  $context['#finished'] = $sandbox['current'] / $sandbox['target'];
 }

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -21,19 +21,16 @@ function islandora_xmlsitemap_uninstall() {
  * Implements hook_install().
  */
 function islandora_xmlsitemap_install() {
-  islandora_xmlsitemap_set_initial_value();
+  // XXX: Taking advantage of the update hook's batch functionality to run the
+  // same batch on install as one would have to in the update hook.
+  islandora_xmlsitemap_update_7000();
 }
 
 /**
  * Implements hook_schema().
- *
- * @see https://jira.duraspace.org/browse/ISLANDORA-1784
  */
 function islandora_xmlsitemap_schema() {
   return array(
-    // XXX: This table satisfies a race condition (details in the @see for this
-    // method); the best way to satisfy this condition was using an
-    // auto-incrementing ID in a table.
     'islandora_xmlsitemap_entry_ids' => array(
       'description' => 'Autoincrementing table to store IDs we can use for xmlsitemap table entries.',
       'fields' => array(
@@ -55,33 +52,44 @@ function islandora_xmlsitemap_schema() {
 
 /**
  * Add the ID table schema in.
+ *
+ * XXX: satisfies a race condition (details in the @see below); the best way to
+ * satisfy this condition was using an auto-incrementing ID in a table, but if
+ * islandora_xmlsitemap is already in use, the ID likely can't simply start at
+ * 1. This function iterates the auto-incrementing ID field to the point where
+ * it's supposed to be. It's a little bit goofy to do it this way, but it
+ * ensures that the method we're using to set the initial ID is database-
+ * agnostic.
+ *
+ * @see https://jira.duraspace.org/browse/ISLANDORA-1784
  */
 function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
-  islandora_xmlsitemap_set_initial_value();
-}
-
-/**
- * Sets the initial ID value of the islandora_xmlsitemap_entry_ids table.
- *
- * XXX: It's possible for the 'custom' type in xmlsitemap to already be in use,
- * so we're just making sure we're out of range of existing IDs.
- */
-function islandora_xmlsitemap_set_initial_value() {
-  // Get the target initial value.
-  $q = db_select('xmlsitemap', 'x');
-  $q->addExpression('MAX(id)');
-  $q->condition('type', 'custom', '=');
-  $current_id = $q->execute()->fetchField();
-  $target = $current_id !== FALSE ? $current_id + 1 : 1;
-
-  // Insert it.
-  $q = db_insert('islandora_xmlsitemap_entry_ids')
-    ->fields(array(
-      'pid' => NULL,
-      'id' => $target,
-    ))
-    ->execute();
-  // Delete it.
   module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
-  islandora_xmlsitemap_delete_increment_record(NULL);
+  if (!isset($sandbox['target'])) {
+    // Create our table, if it doesn't exist.
+    if (!db_table_exists('islandora_xmlsitemap_entry_ids')) {
+      $schema = islandora_xmlsitemap_schema();
+      db_create_table('islandora_xmlsitemap_entry_ids', $schema['islandora_xmlsitemap_entry_ids']);
+    }
+    // Set an initial value.
+    islandora_xmlsitemap_insert_increment_record(NULL);
+    // And immediately give it the boot.
+    islandora_xmlsitemap_delete_increment_record(NULL);
+    // Get the current max.
+    $q = db_select('xmlsitemap', 'x');
+    $q->addExpression('MAX(id)');
+    $q->condition('type', 'custom', '=');
+    $current_id = $q->execute()->fetchField();
+    $sandbox['target'] = $current_id !== FALSE ? $current_id : 1;
+    $sandbox['current'] = 1;
+  }
+
+  // Start filling in records.
+  foreach (array_fill(0, min(1000, $sandbox['target'] - $sandbox['current']), NULL) as $increment) {
+    islandora_xmlsitemap_get_incremented_id($increment);
+    $sandbox['current']++;
+  }
+
+  // Are we done?
+  $context['#finished'] = $sandbox['current'] / $sandbox['target'];
 }

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -57,8 +57,6 @@ function islandora_xmlsitemap_schema() {
  * Add the ID table schema in.
  */
 function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
-  $schema = islandora_xmlsitemap_schema();
-  db_create_table('islandora_xmlsitemap_entry_ids', $schema['islandora_xmlsitemap_entry_ids']);
   islandora_xmlsitemap_set_initial_value();
 }
 

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -21,16 +21,19 @@ function islandora_xmlsitemap_uninstall() {
  * Implements hook_install().
  */
 function islandora_xmlsitemap_install() {
-  // XXX: Taking advantage of the update hook's batch functionality to run the
-  // same batch on install as one would have to in the update hook.
-  islandora_xmlsitemap_update_7000();
+  islandora_xmlsitemap_set_initial_value();
 }
 
 /**
  * Implements hook_schema().
+ *
+ * @see https://jira.duraspace.org/browse/ISLANDORA-1784
  */
 function islandora_xmlsitemap_schema() {
   return array(
+    // XXX: This table satisfies a race condition (details in the @see for this
+    // method); the best way to satisfy this condition was using an
+    // auto-incrementing ID in a table.
     'islandora_xmlsitemap_entry_ids' => array(
       'description' => 'Autoincrementing table to store IDs we can use for xmlsitemap table entries.',
       'fields' => array(
@@ -52,44 +55,33 @@ function islandora_xmlsitemap_schema() {
 
 /**
  * Add the ID table schema in.
- *
- * XXX: satisfies a race condition (details in the @see below); the best way to
- * satisfy this condition was using an auto-incrementing ID in a table, but if
- * islandora_xmlsitemap is already in use, the ID likely can't simply start at
- * 1. This function iterates the auto-incrementing ID field to the point where
- * it's supposed to be. It's a little bit goofy to do it this way, but it
- * ensures that the method we're using to set the initial ID is database-
- * agnostic.
- *
- * @see https://jira.duraspace.org/browse/ISLANDORA-1784
  */
 function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
+  islandora_xmlsitemap_set_initial_value();
+}
+
+/**
+ * Sets the initial ID value of the islandora_xmlsitemap_entry_ids table.
+ *
+ * XXX: It's possible for the 'custom' type in xmlsitemap to already be in use,
+ * so we're just making sure we're out of range of existing IDs.
+ */
+function islandora_xmlsitemap_set_initial_value() {
+  // Get the target initial value.
+  $q = db_select('xmlsitemap', 'x');
+  $q->addExpression('MAX(id)');
+  $q->condition('type', 'custom', '=');
+  $current_id = $q->execute()->fetchField();
+  $target = $current_id !== FALSE ? $current_id + 1 : 1;
+
+  // Insert it.
+  $q = db_insert('islandora_xmlsitemap_entry_ids')
+    ->fields(array(
+      'pid' => NULL,
+      'id' => $target,
+    ))
+    ->execute();
+  // Delete it.
   module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
-  if (!isset($sandbox['target'])) {
-    // Create our table, if it doesn't exist.
-    if (!db_table_exists('islandora_xmlsitemap_entry_ids')) {
-      $schema = islandora_xmlsitemap_schema();
-      db_create_table('islandora_xmlsitemap_entry_ids', $schema['islandora_xmlsitemap_entry_ids']);
-    }
-    // Set an initial value.
-    islandora_xmlsitemap_insert_increment_record(NULL);
-    // And immediately give it the boot.
-    islandora_xmlsitemap_delete_increment_record(NULL);
-    // Get the current max.
-    $q = db_select('xmlsitemap', 'x');
-    $q->addExpression('MAX(id)');
-    $q->condition('type', 'custom', '=');
-    $current_id = $q->execute()->fetchField();
-    $sandbox['target'] = $current_id !== FALSE ? $current_id : 1;
-    $sandbox['current'] = 1;
-  }
-
-  // Start filling in records.
-  foreach (array_fill(0, min(1000, $sandbox['target'] - $sandbox['current']), NULL) as $increment) {
-    islandora_xmlsitemap_get_incremented_id($increment);
-    $sandbox['current']++;
-  }
-
-  // Are we done?
-  $context['#finished'] = $sandbox['current'] / $sandbox['target'];
+  islandora_xmlsitemap_delete_increment_record(NULL);
 }

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -83,7 +83,7 @@ function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
   }
 
   // Start filling in records.
-  foreach (array_fill(0, min(100, $sandbox['target'] - $sandbox['current']), NULL) as $increment) {
+  foreach (array_fill(0, min(1000, $sandbox['target'] - $sandbox['current']), NULL) as $increment) {
     islandora_xmlsitemap_get_incremented_id($increment);
     $sandbox['current']++;
   }

--- a/islandora_xmlsitemap.install
+++ b/islandora_xmlsitemap.install
@@ -57,6 +57,8 @@ function islandora_xmlsitemap_schema() {
  * Add the ID table schema in.
  */
 function islandora_xmlsitemap_update_7000(&$sandbox = array()) {
+  $schema = islandora_xmlsitemap_schema();
+  db_create_table('islandora_xmlsitemap_entry_ids', $schema['islandora_xmlsitemap_entry_ids']);
   islandora_xmlsitemap_set_initial_value();
 }
 

--- a/islandora_xmlsitemap.module
+++ b/islandora_xmlsitemap.module
@@ -21,6 +21,7 @@ function islandora_xmlsitemap_cron() {
  */
 function islandora_xmlsitemap_islandora_object_purged($pid) {
   module_load_include('inc', 'islandora_xmlsitemap', 'includes/utilities');
+  module_load_include('inc', 'islandora_xmlsitemap', 'includes/db');
 
   $q = <<<EOQ
 SELECT id
@@ -44,6 +45,7 @@ EOQ;
       ));
     }
   }
+  islandora_xmlsitemap_delete_increment_record($pid);
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1784
# What does this Pull Request do?

Adds a new table and functionality that has the ability to provide unique, auto-incrementing IDs for the xmlsitemap table for Islandora objects.

While we're in the neighbourhood, it also fixes [this bug](https://github.com/Islandora/islandora_xmlsitemap/pull/26/files#diff-aba45feb5d0612f298ec9b742ae7e63fL16) that causes namespace restriction enforcement to become disabled when `xmlsitemap` is uninstalled.
# What's new?

Nothing really, from a UI/UX perspective. This should all happen behind the scenes.
# How should this be tested?

Because this fixes an issue where concurrent ingests can clash when trying to insert records into `xmlsitemap`, tests should be done using concurrent, high-speed ingests. It typically triggers when multiple concurrent threads are each doing ingests at a rate of < 0.5 seconds per object.

I've been using a combination of [TMH](https://github.com/discoverygarden/ten_million_with_a_hat) with [GNU Parallel](https://www.gnu.org/software/parallel/); run five jobs each ingesting 2000 stub objects simultaneously and I've hit `PDOException`s 100% of the time.

This also needs to be tested against a fresh install of `islandora_xmlsitemap` and an install that's existed for a while (i.e., has records in the `xmlsitemap` table).
# Additional Notes:

The ticket has more info, but the gist is that is a workaround to prevent a condition where you could potentially try to insert the same ID twice into the `xmlsitemap` table, as `xmlsitemap` IDs are unique but do not auto-increment.

The solution (unconventionally) calls an update hook out of the .install to make use of the update batch functionality. It's a weird solution that aligns the auto-incrementing ID at install/update time in a way that lets us not have to worry about what database is on the back-end.

I'm not personally the biggest fan of it, but it's better than having to batch-reassign the IDs of existing records in the `xmlsitemap` table. If someone has a better idea, I'd implement that.
# Interested parties

@dltj maintains this module.
