### PR TITLE
Form handler forces $cutoff to -1

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -82,7 +82,7 @@ function islandora_xmlsitemap_admin_form_submit(&$form, &$form_state) {
     }
 
     module_load_include('inc', 'islandora_xmlsitemap', 'includes/batch');
-    $batch = islandora_xmlsitemap_get_batch(100, -1);
+    $batch = islandora_xmlsitemap_get_batch(100, NULL);
     batch_set($batch);
   }
   elseif ($button == 'submit') {


### PR DESCRIPTION
**JIRA Ticket**: None

# What does this Pull Request do?

When using the form `islandora_xmlsitemap_get_batch()` is always called with a cutoff of `-1`. This will result in all records being processed regardless of what is entered into the 'Maximum Number of Islandora links to process at once' form field.

The proposed solution is to set the `$cutoff` parameter to `NULL` at this point. Omitting the parameter when calling `islandora_xmlsitemap_get_batch()` would also be valid since the default `cutoff` parameter value is `NULL`. However I find explicitly setting it to `NULL` to more clear.

# What's new?
* The settings in the **'Maximum Number of Islandora links to process at once' form field will no longer be ignored**.
A **side effect** of this is that the "regenerate all" button will only generate all records up to the nth record (depending on the form value) at which point the batch will finish. From this point onward the user will have to click the "generate remaining" button to continue generating.

# How should this be tested?
In the form:
1. Set the 'Maximum Number of Islandora links to process at once' form field to a value **lower than the amount of records remaining to be processed** based on the last_modified date that is currently set in the form.

2. Click the "generate remaining" button.

3. The batch should finish when the number of records specified in the form has been processed. During the processing the "total" value should reflect the number specified in the form (exactly).

# Additional Notes:
None.

# Interested parties
@Islandora/7-x-1-x-committers
