### PR TITLE
Add instruction for preventing inactive objects from being added

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Objects must be publicly (anonymously) available to be included in the XML Sitem
 1. Ensure that the anonymous Drupal user has the "View repository objects" permission (admin/people/permissions).
 1. XACML permissions override the Drupal "View repository objects" permission.  Make sure that there are no extra XACML permissions on the object.
 
-Please also note that objects marked as "inactive", whether manually or by using the [Simple Workflow](https://github.com/Islandora/islandora_simple_workflow) module, will still be indexed by default.
+Please also note that objects marked as "inactive", whether manually or by using the [Simple Workflow](https://github.com/Islandora/islandora_simple_workflow) module, will still be indexed by default. You can prevent this by enabling the option "Lock down inactive and deleted objects" under admin/islandora/configure.
 
 Larger sites with greater than 100,000 objects may encounter issues during the sitemap building process with the default configuration, such as the process hanging around a specific number indefinitely or exiting the process entirely before completion. These users may want to try unchecking the "Prefetch URL aliases during sitemap generation" option found on the xmlsitemap admin configuration page (/admin/config/search/xmlsitemap/settings) and trying the process again.
 


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2215][1].

[1]: https://jira.duraspace.org/browse/ISLANDORA-2215

# What does this Pull Request do?

Update the README with a sentence about preventing inactive objects from being added to the XML sitemap.

# What's new?

I added

> You can prevent this by enabling the option "Lock down inactive and deleted objects" under admin/islandora/configure.

# How should this be tested?

n/a

# Additional Notes:

n/a

# Interested parties
@bryjbrown and @Islandora/7-x-1-x-committers
